### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,7 +14,7 @@
     ],
     "description": "Visualize and build augmentation pipeline with ImgAug",
     "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.14.0",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",
     "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
         "data operations"
     ],
     "description": "Visualize and build augmentation pipeline with ImgAug",
-    "docker_image": "supervisely/data-operations:6.73.406",
+    "docker_image": "supervisely/data-operations:6.73.564",
     "instance_version": "6.14.0",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -1,30 +1,30 @@
 {
-    "name": "ImgAug Studio",
-    "type": "app",
-    "categories": [
-        "neural network",
-        "images",
-        "object detection",
-        "semantic segmentation",
-        "instance segmentation",
-        "classification",
-        "nn tools",
-        "augmentation",
-        "data operations"
-    ],
-    "description": "Visualize and build augmentation pipeline with ImgAug",
-    "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "gui_template": "src/gui.html",
-    "task_location": "workspace_tasks",
-    "icon": "https://img.icons8.com/fluent/100/000000/lab-items.png",
-    "icon_background": "#FFFFFF",
-    "disable_stop": true,
-    "context_menu": {
-        "target": [
-            "images_project"
-        ]
-    },
-    "poster": "https://user-images.githubusercontent.com/48245050/182815780-667460f6-b056-4e18-9d06-da5b7de01175.png"
+  "name": "ImgAug Studio",
+  "type": "app",
+  "categories": [
+    "neural network",
+    "images",
+    "object detection",
+    "semantic segmentation",
+    "instance segmentation",
+    "classification",
+    "nn tools",
+    "augmentation",
+    "data operations"
+  ],
+  "description": "Visualize and build augmentation pipeline with ImgAug",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "gui_template": "src/gui.html",
+  "task_location": "workspace_tasks",
+  "icon": "https://img.icons8.com/fluent/100/000000/lab-items.png",
+  "icon_background": "#FFFFFF",
+  "disable_stop": true,
+  "context_menu": {
+    "target": [
+      "images_project"
+    ]
+  },
+  "poster": "https://user-images.githubusercontent.com/48245050/182815780-667460f6-b056-4e18-9d06-da5b7de01175.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-supervisely==6.72.217
+supervisely==6.73.564
 
 # already in sly:
 # imgaug==0.4.0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,11 +1,1 @@
 supervisely==6.73.564
-
-# already in sly:
-# imgaug==0.4.0
-# imagecorruptions==1.1.2
-
-# for docstring-to-html:
-# Sphinx==3.4.3
-# sphinx-copybutton==0.3.1
-# sphinx-rtd-theme==0.5.1
-# beautifulsoup4==4.9.3

--- a/html_doc/generate-docstring-html.py
+++ b/html_doc/generate-docstring-html.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from bs4 import BeautifulSoup
-import supervisely_lib as sly
+import supervisely as sly
 
 def pretty_py_html(text, output, html_name="index"):
     # Sphinx conf.py


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
